### PR TITLE
(SSPP-315): Implemented delete on associated note files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - (SSPP-302): Documentation to all functions to make auto-complete more useful when modifying the application
+- (SSPP-315): Automation to delete all related S3 stored note file data from cloud storage when a classroom is deleted
 
 ### Fixed
 

--- a/src/modules/class/classroom.repository.ts
+++ b/src/modules/class/classroom.repository.ts
@@ -52,7 +52,8 @@ export class ClassroomRepository {
 		return this.crModel.findOne({
 			where: {
 				id
-			}
+			},
+			include: [ Note ]
 		})
 	}
 

--- a/src/modules/files/files.service.ts
+++ b/src/modules/files/files.service.ts
@@ -137,6 +137,7 @@ export class FilesService {
 	/**
 	 * Used to delete a file from S3 object storage
 	 * @param fileUri A unique fileURI that points to a file in S3 storage 
+	 * @param spaceType The type of space where the file is being stored (NOTES or IMAGES) **(optional)** - `Default` = NOTES
 	 */
 	async deleteFileWithID(fileUri: string, spaceType: SpaceType = SpaceType.NOTES): Promise<void> {
 		// Init Spaces Connections


### PR DESCRIPTION
This deletes all note files for related notes when a classroom is deleted.

This was due to the issue identified in the related ticket: SSPP-315